### PR TITLE
refactor: use links instead of buttons

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13387,20 +13387,6 @@ function getSimpleMarkdownBlock(text) {
         },
     };
 }
-function getMarkdownBlockWithButton(text, url) {
-    return {
-        type: 'section',
-        text: {
-            type: 'mrkdwn',
-            text,
-        },
-        accessory: {
-            type: 'button',
-            text: { type: 'plain_text', text: 'Open' },
-            url,
-        },
-    };
-}
 /*
  * Posts updates to slack as a single thread.
  */
@@ -13421,7 +13407,7 @@ function postToSlack(context, lastWeekIssues, lastWeekPRs) {
         for (const [repoName, issues] of lastWeekIssues.entries()) {
             if (!issues.length)
                 continue;
-            issuesBlocks.push(getSimpleMarkdownBlock(`*${repoName}*`), ...issues.map((issue) => getMarkdownBlockWithButton(issue.title, issue.url)));
+            issuesBlocks.push(getSimpleMarkdownBlock(`*${repoName}*`), ...issues.map((issue) => getSimpleMarkdownBlock(`<${issue.url}|${issue.title}>`)));
         }
         messages.push(issuesBlocks);
         const PRBlocks = [
@@ -13430,7 +13416,7 @@ function postToSlack(context, lastWeekIssues, lastWeekPRs) {
         for (const [repoName, issues] of lastWeekPRs.entries()) {
             if (!issues.length)
                 continue;
-            PRBlocks.push(getSimpleMarkdownBlock(`*${repoName}*`), ...issues.map((issue) => getMarkdownBlockWithButton(issue.title, issue.url)));
+            PRBlocks.push(getSimpleMarkdownBlock(`*${repoName}*`), ...issues.map((issue) => getSimpleMarkdownBlock(`<${issue.url}|${issue.title}>`)));
         }
         messages.push(PRBlocks);
         for (const message of messages) {

--- a/src/slack.ts
+++ b/src/slack.ts
@@ -10,21 +10,6 @@ function getSimpleMarkdownBlock(text: string) {
     }
 }
 
-function getMarkdownBlockWithButton(text: string, url: string) {
-    return {
-        type: 'section',
-        text: {
-            type: 'mrkdwn',
-            text,
-        },
-        accessory: {
-            type: 'button',
-            text: { type: 'plain_text', text: 'Open' },
-            url,
-        },
-    }
-}
-
 /*
  * Posts updates to slack as a single thread.
  */
@@ -59,7 +44,7 @@ export default async function postToSlack(
         issuesBlocks.push(
             getSimpleMarkdownBlock(`*${repoName}*`),
             ...issues.map((issue: Issue) =>
-                getMarkdownBlockWithButton(issue.title, issue.url),
+                getSimpleMarkdownBlock(`<${issue.url}|${issue.title}>`),
             ),
         )
     }
@@ -75,7 +60,7 @@ export default async function postToSlack(
         PRBlocks.push(
             getSimpleMarkdownBlock(`*${repoName}*`),
             ...issues.map((issue: Issue) =>
-                getMarkdownBlockWithButton(issue.title, issue.url),
+                getSimpleMarkdownBlock(`<${issue.url}|${issue.title}>`),
             ),
         )
     }


### PR DESCRIPTION
- This swaps the inline buttons for the neater text links.

![image](https://user-images.githubusercontent.com/6210361/127199388-56405934-cfb4-4c88-b6e0-56dfd091473b.png)
